### PR TITLE
Add support for login domain (used by mediawiki ldap authentication extension)

### DIFF
--- a/src/ApiUser.php
+++ b/src/ApiUser.php
@@ -21,20 +21,27 @@ class ApiUser {
 	private $username;
 
 	/**
+	 * @var string
+	 */
+	private $domain;
+
+	/**
 	 * @param string $username
 	 * @param string $password
+	 * @param string|null $domain
 	 *
 	 * @throws \InvalidArgumentException
 	 */
-	public function __construct( $username, $password ) {
-		if( !is_string( $username ) || !is_string( $password ) ) {
-			throw new InvalidArgumentException( 'Username and Password must both be strings' );
+	public function __construct( $username, $password, $domain = null ) {
+		if( !is_string( $username ) || !is_string( $password ) || !( is_null( $domain ) || is_string( $domain ) ) ) {
+			throw new InvalidArgumentException( 'Username, Password and Domain must all be strings' );
 		}
 		if( empty( $username ) || empty( $password ) ) {
 			throw new InvalidArgumentException( 'Username and Password are not allowed to be empty' );
 		}
 		$this->username = $username;
 		$this->password = $password;
+		$this->domain   = $domain;
 	}
 
 	/**
@@ -55,12 +62,20 @@ class ApiUser {
 
 	/**
 	 * @since 0.1
+	 * @return string
+	 */
+	public function getDomain() {
+		return $this->domain;
+	}
+
+	/**
+	 * @since 0.1
 	 * @param mixed $other
 	 *
 	 * @return bool
 	 */
 	public function equals( $other ) {
-		if( $other instanceof ApiUser && $this->username == $other->getUsername() && $this->password == $other->getPassword() ) {
+		if( $other instanceof ApiUser && $this->username == $other->getUsername() && $this->password == $other->getPassword() && $this->domain == $other->getDomain() ) {
 			return true;
 		}
 		return false;

--- a/src/MediawikiApi.php
+++ b/src/MediawikiApi.php
@@ -169,7 +169,8 @@ class MediawikiApi {
 	public function login( ApiUser $apiUser ) {
 		$credentials = array(
 			'lgname' => $apiUser->getUsername(),
-			'lgpassword' => $apiUser->getPassword()
+			'lgpassword' => $apiUser->getPassword(),
+			'lgdomain' => $apiUser->getDomain()
 		);
 
 		$result = $this->postRequest( new SimpleRequest( 'login', $credentials ) );


### PR DESCRIPTION
Please consider these changes to support domain logins when the mediawiki installation your talking to is using for example the LDAP authentication extension.
I could not test if my changes still work on a non domain-enabled mediawiki as I currently don't have such an installation to test on.
