### PR TITLE
Remove private tag

### DIFF
--- a/src/MediawikiApi.php
+++ b/src/MediawikiApi.php
@@ -86,8 +86,6 @@ class MediawikiApi implements LoggerAwareInterface {
 	}
 
 	/**
-	 * @access private
-	 *
 	 * @param string $apiUrl The API Url
 	 * @param Client|null $client Guzzle Client
 	 * @param MediawikiSession|null $session Inject a custom session here


### PR DESCRIPTION
The WMDE Fundraising code has been using this constructor since version 0.1.2. I just noticed it was marked as private while refactoring some code there. By the looks of it, the reason why its marked as such, but not declared private is that the tests in this component need to inject the Guzzle Client. Well guess what, users of this component also need to be able to do this if they want to do system and edge-to-edge testing and see what is send over the wire.
