### PR TITLE
Update branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.0.x-dev"
+			"dev-master": "2.2.x-dev"
 		}
 	}
 }


### PR DESCRIPTION
Right now people that have ~2.0.0@dev will get master, which is either at 2.1.x or 2.2.x.
