### PR TITLE
Add PHP version requirement to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
 		}
 	],
 	"require": {
+		"php": ">=5.5",
 		"guzzlehttp/guzzle": "~6.0",
 		"guzzlehttp/promises": "~1.0",
 		"psr/log": "~1.0"


### PR DESCRIPTION
I'm not sure this is the min version. It's my guess as this is
the min version that is tested against.
