### PR TITLE
Expose the API URL of MediawikiApi

### DIFF
--- a/src/MediawikiApi.php
+++ b/src/MediawikiApi.php
@@ -104,6 +104,16 @@ class MediawikiApi implements MediawikiApiInterface, LoggerAwareInterface {
 	}
 
 	/**
+	 * Get the API URL (the URL to which API requests are sent, usually ending in api.php).
+	 * This is useful if you've created this object via MediawikiApi::newFromPage().
+	 * @return string The API URL.
+	 */
+	public function getApiUrl()
+	{
+		return $this->apiUrl;
+	}
+
+	/**
 	 * @return ClientInterface
 	 */
 	private function getClient() {

--- a/src/MediawikiApi.php
+++ b/src/MediawikiApi.php
@@ -108,8 +108,7 @@ class MediawikiApi implements MediawikiApiInterface, LoggerAwareInterface {
 	 * This is useful if you've created this object via MediawikiApi::newFromPage().
 	 * @return string The API URL.
 	 */
-	public function getApiUrl()
-	{
+	public function getApiUrl() {
 		return $this->apiUrl;
 	}
 


### PR DESCRIPTION
This just adds MediawikiApi::getApiUrl() as a means to retrieve
the API URL. Mostly only useful if you've created an object via
MediawikiApi::newFromPage and want to get the URL for use
elsewhere.
