### PR TITLE
Use DOM instead of SimpleXml for parsing HTML

### DIFF
--- a/src/RsdException.php
+++ b/src/RsdException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mediawiki\Api;
+
+use Exception;
+
+/**
+ * An exception raised when an issue is encountered with Really Simple Discovery.
+ * @see https://en.wikipedia.org/wiki/Really_Simple_Discovery
+ */
+class RsdException extends Exception
+{
+}

--- a/tests/Integration/MediawikiApiTest.php
+++ b/tests/Integration/MediawikiApiTest.php
@@ -19,6 +19,18 @@ class MediawikiApiTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @covers Mediawiki\Api\MediawikiApi::newFromPage
+	 * @expectedException Mediawiki\Api\RsdException
+	 * @expectedExceptionMessageRegExp |Unable to find RSD URL in page.*|
+	 */
+	public function testNewFromPageInvalidHtml() {
+		// This could be any URL that doesn't contain the RSD link, but the README URL
+		// is a test-accessible one that doesn't return 404.
+		$nonWikiPage = str_replace( 'api.php', 'README', TestEnvironment::newInstance()->getApiUrl() );
+		MediawikiApi::newFromPage( $nonWikiPage );
+	}
+
+	/**
 	 * @covers Mediawiki\Api\MediawikiApi::getRequest
 	 * @covers Mediawiki\Api\MediawikiApi::getClientRequestOptions
 	 * @covers Mediawiki\Api\MediawikiApi::decodeResponse


### PR DESCRIPTION
To get the RSD URL we parse a page's HTML, but this fails with
SimpleXml when there are non-XML entities (etc.), so this changes
MediawikiApi::newFromPage() to use the PHP DOM library instead.

The docblock was also updated, and a test added.

Bug: https://phabricator.wikimedia.org/T163527