### PR TITLE
Don't fail on libxml errors if the RSD URL can still be found

### DIFF
--- a/tests/Integration/MediawikiApiTest.php
+++ b/tests/Integration/MediawikiApiTest.php
@@ -31,6 +31,28 @@ class MediawikiApiTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Duplicate element IDs break DOMDocument::loadHTML
+	 * @see https://phabricator.wikimedia.org/T163527#3219833
+	 * @covers Mediawiki\Api\MediawikiApi::newFromPage
+	 */
+	public function testNewFromPageWithDuplicateId() {
+		$testPageName = __METHOD__;
+		$testEnv = TestEnvironment::newInstance();
+		$wikiPageUrl = str_replace( 'api.php', "index.php?title=$testPageName", $testEnv->getApiUrl() );
+
+		// Test with no duplicate IDs.
+		$testEnv->savePage( $testPageName, '<p id="unique-id"></p>' );
+		$api1 = MediawikiApi::newFromPage( $wikiPageUrl );
+		$this->assertInstanceOf( MediawikiApi::class, $api1 );
+
+		// Test with duplicate ID.
+		$wikiText = '<p id="duplicated-id"></p><div id="duplicated-id"></div>';
+		$testEnv->savePage( $testPageName, $wikiText );
+		$api2 = MediawikiApi::newFromPage( $wikiPageUrl );
+		$this->assertInstanceOf( MediawikiApi::class, $api2 );
+	}
+
+	/**
 	 * @covers Mediawiki\Api\MediawikiApi::getRequest
 	 * @covers Mediawiki\Api\MediawikiApi::getClientRequestOptions
 	 * @covers Mediawiki\Api\MediawikiApi::decodeResponse

--- a/tests/Integration/TestEnvironment.php
+++ b/tests/Integration/TestEnvironment.php
@@ -4,6 +4,7 @@ namespace Mediawiki\Api\Test\Integration;
 
 use Exception;
 use Mediawiki\Api\MediawikiApi;
+use Mediawiki\Api\SimpleRequest;
 
 /**
  * @author Addshore
@@ -68,4 +69,19 @@ class TestEnvironment {
 		return $this->api;
 	}
 
+	/**
+	 * Save a wiki page.
+	 * @param string $title
+	 * @param string $content
+	 */
+	public function savePage( $title, $content ) {
+
+		$params = [
+			'title' => $title,
+			'text' => $content,
+			'md5' => md5( $content ),
+			'token' => $this->api->getToken(),
+		];
+		$this->api->postRequest( new SimpleRequest( 'edit', $params ) );
+	}
 }


### PR DESCRIPTION
Various things, such as duplicate element IDs or repeated
attributes, break DOMDocument::loadHTML() and so this turns off
the direct reporting (E_ERROR) of these and istead adds them
to the RsdException if the RSD URL really can't be determined
from the HTML. In most cases, the URL can be found correctly
and the errors can be disregarded.

A test is added for this as well, although it does *not* test
for the case when the RSD URL can't be found and there are
libxml errors (because we need to serve up a broken HTML file,
and the mediawiki-api-base test system can only interact with
MediaWiki via the API, which makes it hard to produce broken
HTML that doesn't also have the correct LINK element for the
RSD URL).

A new TestEnvironment::savePage method is added, for easier
creation of test wiki pages.

Bug: https://phabricator.wikimedia.org/T163527