### PR TITLE
Update setLogger method signatures and return types.

### DIFF
--- a/src/Client/Action/ActionApi.php
+++ b/src/Client/Action/ActionApi.php
@@ -84,9 +84,9 @@ class ActionApi implements Requester, LoggerAwareInterface {
 	 *
 	 * @param LoggerInterface $logger The new Logger object.
 	 *
-	 * @return null
+	 * @return void
 	 */
-	public function setLogger( LoggerInterface $logger ) {
+	public function setLogger( LoggerInterface $logger ): void {
 		$this->logger = $logger;
 		$this->tokens->setLogger( $logger );
 	}

--- a/src/Client/Action/Tokens.php
+++ b/src/Client/Action/Tokens.php
@@ -34,9 +34,9 @@ class Tokens implements LoggerAwareInterface {
 	 *
 	 * @param LoggerInterface $logger The new Logger object.
 	 *
-	 * @return null
+	 * @return void
 	 */
-	public function setLogger( LoggerInterface $logger ) {
+	public function setLogger( LoggerInterface $logger ): void {
 		$this->logger = $logger;
 	}
 

--- a/src/Client/Rest/RestApi.php
+++ b/src/Client/Rest/RestApi.php
@@ -83,9 +83,9 @@ class RestApi implements Requester, LoggerAwareInterface {
 	 *
 	 * @param LoggerInterface $logger The new Logger object.
 	 *
-	 * @return null
+	 * @return void
 	 */
-	public function setLogger( LoggerInterface $logger ) {
+	public function setLogger( LoggerInterface $logger ): void {
 		$this->logger = $logger;
 		$this->tokens->setLogger( $logger );
 	}

--- a/src/Guzzle/ClientFactory.php
+++ b/src/Guzzle/ClientFactory.php
@@ -27,7 +27,7 @@ class ClientFactory implements LoggerAwareInterface {
 		$this->config = $config;
 	}
 
-	public function setLogger( LoggerInterface $logger ) {
+	public function setLogger( LoggerInterface $logger ): void {
 		$this->logger = $logger;
 	}
 

--- a/src/Guzzle/MiddlewareFactory.php
+++ b/src/Guzzle/MiddlewareFactory.php
@@ -22,7 +22,7 @@ class MiddlewareFactory implements LoggerAwareInterface {
 		$this->logger = new NullLogger();
 	}
 
-	public function setLogger( LoggerInterface $logger ) {
+	public function setLogger( LoggerInterface $logger ): void {
 		$this->logger = $logger;
 	}
 


### PR DESCRIPTION
## Changes:
- Modified `setLogger` methods in multiple files to explicitly return `void`
- Updated PHPDoc return type from `@return null` to `@return void`
- Files affected:
  - src/Client/Action/ActionApi.php
  - src/Client/Action/Tokens.php
  - src/Client/Rest/RestApi.php
  - src/Guzzle/ClientFactory.php
  - src/Guzzle/MiddlewareFactory.php

## Purpose:
Improve type safety and code clarity by explicitly declaring void return types for methods that don't return a value.